### PR TITLE
Rewrite blog post to focus on personal experience

### DIFF
--- a/blog/2026/04/11-redesigning-my-site-with-claude-code.html
+++ b/blog/2026/04/11-redesigning-my-site-with-claude-code.html
@@ -32,54 +32,48 @@
       </p>
 
       <p>
-        Rather than spending a weekend tweaking CSS and second-guessing color choices, I decided to try
-        something different. I used Claude Code on the cloud through the mobile app, right from my
-        phone, to redesign the entire site in a single session. No laptop, no IDE, no terminal. Just
-        me and my phone.
+        The thing is, I know how to fix it. I've been writing HTML and CSS for years. But this is the
+        kind of task that always falls to the bottom of the list. It's not hard, it's just tedious
+        enough that I never want to sit down and do it. So it sat there, looking the way it looked,
+        for months.
       </p>
 
       <p>
-        The experience was genuinely interesting. I started with a simple prompt: make the site look
-        cleaner and more professional. Claude explored the full codebase first, reading every HTML and
-        CSS file to understand the current structure before proposing any changes. It then rewrote the
-        CSS from scratch with a modern approach: CSS custom properties for theming, a system font stack,
-        flexbox layouts, and proper responsive breakpoints. It restructured the HTML across every page
-        to use semantic elements like nav, main, and section, and added a consistent header with
-        navigation across the site.
+        I ended up redesigning the whole thing from my phone using Claude Code. I was on the couch,
+        not at a desk, and I didn't open a laptop at any point. I just described what I wanted and
+        worked through changes conversationally. The whole thing took maybe an hour.
       </p>
 
       <p>
-        What struck me was how iterative the process felt. It wasn't just a one-shot generation of
-        code. I could ask for changes, like removing the scheduling link, and Claude understood the
-        context of what had already been done. It found every instance across multiple files and
-        removed them cleanly. When merge conflicts came up with the production branch, it resolved
-        those too. It even took a screenshot of the result using a headless browser so I could see
-        what the page looked like without leaving my phone.
+        What surprised me wasn't really the output. The new CSS is fine, the layout is cleaner, the
+        pages are consistent now. What surprised me was how much it felt like the task just stopped
+        being in my way. I'd been avoiding this for a long time not because it was complex but
+        because it was the kind of work that's just boring enough to never prioritize. And suddenly
+        it was done.
       </p>
 
       <p>
-        The whole thing, from the initial redesign to conflict resolution to creating the pull request
-        with a screenshot attached, happened in one continuous conversation on my phone. That's the
-        part that surprised me most. It wasn't just writing code. It was navigating git branches,
-        understanding file relationships, managing state across multiple changes, and interacting
-        with GitHub. All while I was sitting on the couch. It felt less like using a tool and more
-        like pair programming with someone who happens to be very fast at CSS.
+        There were a few moments during the session where I changed my mind. I had it add a
+        scheduling link, then decided I didn't want it. I asked it to remove the link everywhere.
+        Merge conflicts came up when production had diverged and those got resolved too. Each time
+        I just said what I wanted in plain language and moved on. I didn't have to context-switch
+        into "developer mode" to deal with any of it.
       </p>
 
       <p>
         I want to be honest about this because it connects back to something I wrote about in my first
-        post: authenticity. I didn't hand-craft every pixel of this redesign. An AI did the heavy
-        lifting. But the decisions were mine. I chose the direction, I reviewed the output, I asked for
-        adjustments. The end result is something that actually represents what I wanted the site to feel
-        like: clean, simple, professional, without being over-engineered. Which, ironically, is a lot
-        like how I think about engineering leadership.
+        post: authenticity. I didn't hand-craft every pixel of this redesign. But the decisions were
+        all mine. I chose the direction. I reviewed what came back. I pushed back when something
+        didn't feel right. The result looks like what I wanted the site to look like and that's what
+        matters to me.
       </p>
 
       <p>
-        If you're curious about Claude Code, it's worth trying. The fact that I could do all of this
-        from my phone, without ever opening a laptop, says a lot about where development tools are
-        headed. Sometimes the best way to ship something is to have a really fast collaborator, and
-        it turns out you don't even need to be at a desk to do it.
+        The part I keep thinking about is the friction. Or the lack of it. I've shipped plenty of
+        side projects over the years and the pattern is always the same: the interesting work gets
+        done and then the cleanup sits in a branch for six months. This time the cleanup happened
+        the same day I thought about it, from my phone, without any of the usual resistance. I don't
+        know exactly what to make of that yet but it feels like something worth paying attention to.
       </p>
 
       <a class="back-link" href="../../index.html">&larr; Return to Blog</a>


### PR DESCRIPTION
## Summary

- **Rewrites the Claude Code blog post** to focus on the personal experience of finally getting a lingering side project done, rather than listing tool features
- Shifts tone from product pitch to personal reflection on friction, procrastination, and what it felt like when the task just stopped being in the way

## Test plan

- [ ] Open the blog post and verify it renders correctly
- [ ] Read through and confirm the tone feels personal, not promotional

https://claude.ai/code/session_01TZoVdy1ekYLPnvtGSinMmK